### PR TITLE
Fix scrollbar position attached in web

### DIFF
--- a/lib/src/flutter_syntax_view.dart
+++ b/lib/src/flutter_syntax_view.dart
@@ -47,6 +47,20 @@ class SyntaxViewState extends State<SyntaxView> {
   static const double MAX_FONT_SCALE_FACTOR = 3.0;
   static const double MIN_FONT_SCALE_FACTOR = 0.5;
   double _fontScaleFactor = 1.0;
+  late ScrollController _verticalScrollController;
+
+  @override
+  void initState() {
+    super.initState();
+    _verticalScrollController = ScrollController();
+  }
+
+  @override
+  void dispose() {
+    _verticalScrollController.dispose();
+    super.dispose();
+  }
+
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +72,9 @@ class SyntaxViewState extends State<SyntaxView> {
           color: widget.syntaxTheme!.backgroundColor,
           constraints: widget.expanded ? BoxConstraints.expand() : null,
           child: Scrollbar(
+            controller: _verticalScrollController,
               child: SingleChildScrollView(
+                controller: _verticalScrollController,
                   child: SingleChildScrollView(
                       scrollDirection: Axis.horizontal,
                       child: widget.withLinesCount


### PR DESCRIPTION
Separate the scrollController for vertical ScrollViews, ensuring it synchronizes the scrollbar and SingleChildScrollView to fix the following bug on the web when scrolling inside a SyntaxView.

![image](https://github.com/user-attachments/assets/2d0b4682-88bb-4ad5-8464-6a5ed7b4a406)

This behavior seems to be related to how Flutter uses the PrimaryScrollController on web and desktop platforms.
[PrimaryController](https://api.flutter.dev/flutter/widgets/PrimaryScrollController-class.html)